### PR TITLE
Fix endless sacctmgr retries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,8 +83,8 @@ runs:
     - name: Add Slurm Account
       shell: bash -e {0}
       run: |
-        sudo retry --until=success -- sacctmgr -i create account "Name=runner"
-        sudo retry --until=success -- sacctmgr -i create user "Name=runner" "Account=runner"
+        sudo retry --times=24 --delay=5 --until=success -- sacctmgr -i create account "Name=runner"
+        sudo retry --times=24 --delay=5 --until=success -- sacctmgr -i create user "Name=runner" "Account=runner"
 
     - name: Test srun submission
       shell: bash -e {0}


### PR DESCRIPTION
## Summary
- stop endless retry loops by limiting the sacctmgr attempts

## Testing
- `retry --help`

------
https://chatgpt.com/codex/tasks/task_e_684b7634e9548323a59ee3f556eda5af